### PR TITLE
Altered to enable passing a property-file in via the command line

### DIFF
--- a/src/main/java/org/cmatta/kafka/streams/wikipedia/MessageMonitor.java
+++ b/src/main/java/org/cmatta/kafka/streams/wikipedia/MessageMonitor.java
@@ -15,6 +15,9 @@ import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.cmatta.kafka.connect.irc.Message;
 
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.IOException;
 import java.util.Properties;
 
 /**
@@ -22,16 +25,57 @@ import java.util.Properties;
  */
 public class MessageMonitor {
   public static void main(String[] args) throws Exception {
-    Properties props = new Properties();
-    props.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-wikipedia-monitor");
-    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
-    props.put(StreamsConfig.ZOOKEEPER_CONNECT_CONFIG, "zookeeper:2181");
-    props.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://schemaregistry:8081");
-    props.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-    props.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, SpecificAvroSerde.class);
-    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-    props.put("consumer.interceptor.classes", "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor");
-    props.put("producer.interceptor.classes", "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor");
+    Properties streamProps = new Properties();
+    Properties appProps = new Properties();
+
+    streamProps.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-wikipedia-monitor");
+    streamProps.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+    streamProps.put(StreamsConfig.ZOOKEEPER_CONNECT_CONFIG, "zookeeper:2181");
+    streamProps.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://schemaregistry:8081");
+    streamProps.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+    streamProps.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, SpecificAvroSerde.class);
+    streamProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    streamProps.put("consumer.interceptor.classes", "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor");
+    streamProps.put("producer.interceptor.classes", "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor");
+
+        // Override defaults with explicit input (if present)
+    String[] pNames = {StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, StreamsConfig.ZOOKEEPER_CONNECT_CONFIG, AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG};
+    String pValue;
+    if (args.length > 0) {
+        System.out.println("Reading property overrides from "+args[0]);
+
+            // Known properties that we can override
+        InputStream propInputStream = null;
+
+        try {
+            propInputStream = new FileInputStream(args[0]);
+            appProps.load(propInputStream);
+
+            for (String prop : pNames) {
+                pValue=appProps.getProperty(prop);
+                if (pValue != null) {
+                    System.out.println("  Overriding "+prop+" with "+pValue);
+                    streamProps.put(prop, pValue);
+                }
+            }
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        } finally {
+            if (propInputStream != null) {
+                propInputStream.close();
+            }
+        }
+    }
+
+        // Lastly, command-line overrides (highest precedence)
+    System.out.println("Checking for command-line overrides");
+    for (String prop : pNames) {
+        pValue=System.getProperty(prop);
+        if (pValue != null) {
+            System.out.println("  Overriding "+prop+" with "+pValue);
+            streamProps.put(prop, pValue);
+        }
+    }
 
     KStreamBuilder builder = new KStreamBuilder();
 
@@ -41,7 +85,7 @@ public class MessageMonitor {
         .filter((k, v) -> k != null && v != null).to("wikipedia.parsed");
 
 //    TODO Add KTable example code
-    final KafkaStreams streams = new KafkaStreams(builder, props);
+    final KafkaStreams streams = new KafkaStreams(builder, streamProps);
     streams.start();
 
     // Add shutdown hook to respond to SIGTERM and gracefully close Kafka Streams


### PR DESCRIPTION
... and handling  "-D" options for key parameters

NOTE: This is a first pass ... so only a few properties were supported
(zookeeper.connect, bootstrap.servers, schema.registry.url).